### PR TITLE
allow higher version of websockets to avoid clash with core ring

### DIFF
--- a/custom_components/ms_teams_websockets/manifest.json
+++ b/custom_components/ms_teams_websockets/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://www.github.com/malkstar/ms_teams_websockets/issues",
   "requirements": [
-    "websockets==11.0.2"
+    "websockets>=11.0.2,<14"
   ],
   "version": "0.0.7"
 }


### PR DESCRIPTION
resolves an bug where this integration prevents the core ring integration from loading due to dependency clash.

as discussed here - https://github.com/home-assistant/core/issues/130725

this bug is effecting multiple integrations.

this allows higher version of websockets to be used but keeps below 14 as there may be some breaking changes above that. further testing and possible changes should be looked at before upgrading higher than that.